### PR TITLE
Container view should be QTouchposeTouchesView, not QTouchposeFingerView

### DIFF
--- a/Touchposé Example/Source/QTouchposeApplication.m
+++ b/Touchposé Example/Source/QTouchposeApplication.m
@@ -309,7 +309,7 @@ static void UIWindow_new_didAddSubview(UIWindow *window, SEL _cmd, UIView *view)
         if (_touchView == nil && self.keyWindow)
         {
             UIWindow *window = self.keyWindow;
-            _touchView = [[QTouchposeFingerView alloc] initWithFrame:window.bounds];
+            _touchView = [[QTouchposeTouchesView alloc] initWithFrame:window.bounds];
             _touchView.backgroundColor = [UIColor clearColor];
             _touchView.opaque = NO;
             _touchView.userInteractionEnabled = NO;


### PR DESCRIPTION
Previously the container view was itself a QTouchposeFingerView, which could cause an extra touch to be drawn. QTouchposeTouchesView was unused, but seems like it was intended to be used here.
