### PR TITLE
Refresh touches feedback before processing the corresponding events.

### DIFF
--- a/Touchpose Example/Source/QTouchposeApplication.m
+++ b/Touchpose Example/Source/QTouchposeApplication.m
@@ -168,9 +168,9 @@ static void UIWindow_new_didAddSubview(UIWindow *window, SEL _cmd, UIView *view)
 
 - (void)sendEvent:(UIEvent *)event
 {
-    [super sendEvent:event];
     if (_showTouches)
         [self updateTouches:[event allTouches]];
+    [super sendEvent:event];
 }
 
 #pragma mark - QApplication


### PR DESCRIPTION
This fixes an issue where a released touch would linger on screen when the event processing blocks the main thread, thus making the feedback more faithful to the actual user touches, 
